### PR TITLE
Feature/higashida text underline：Textウィジェットに下線をひく

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -167,7 +167,18 @@ class _MyHomePageState extends State<MyHomePage> {
                                   height: 72,
                                   width: 85,
                                   child: Row(
-                                    children: const [Text('28'), Text('件')],
+                                    children: const [
+                                      Text(
+                                        '28',
+                                        style: TextStyle(
+                                            fontSize: 34,
+                                            fontWeight: FontWeight.bold,
+                                            decoration:
+                                                TextDecoration.underline,
+                                            color: Color(0xff68C8CE)),
+                                      ),
+                                      Text('件')
+                                    ],
                                   ),
                                 ),
                               ]),


### PR DESCRIPTION
## 対応したこと

・テキストに下線を引く
・フォントを太字にする
・フォントサイズを設定する
・色を設定する
などをしました

とくにFlutterで色を指定する場合はカラーコードを使えないと思っていましたが、Color(0xff~)という形で設定できるようです。

## 参考記事
https://stackoverflow.com/questions/50081213/how-do-i-use-hexadecimal-color-strings-in-flutter